### PR TITLE
fix: permissions in workflows

### DIFF
--- a/.github/workflows/commitlint.yaml
+++ b/.github/workflows/commitlint.yaml
@@ -8,9 +8,6 @@ jobs:
     check:
         runs-on: ubuntu-latest
 
-        permissions:
-          contents: write
-
         steps:
         - uses: actions/checkout@v4
           with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,9 +6,6 @@ jobs:
     linting:
         runs-on: ubuntu-latest
 
-        permissions:
-          contents: write
-
         steps:
         - uses: actions/checkout@v4
 
@@ -32,9 +29,6 @@ jobs:
     type-check:
         runs-on: ubuntu-latest
 
-        permissions:
-          contents: write
-
         steps:
         - uses: actions/checkout@v4
 
@@ -51,9 +45,6 @@ jobs:
 
     functional:
         runs-on: ${{ matrix.os }}
-
-        permissions:
-          contents: write
 
         strategy:
             matrix:

--- a/.github/workflows/title.yaml
+++ b/.github/workflows/title.yaml
@@ -11,9 +11,6 @@ jobs:
     check:
         runs-on: ubuntu-latest
 
-        permissions:
-          contents: write
-
         steps:
         - uses: actions/checkout@v4
 


### PR DESCRIPTION
### What I did

Add `write` permissions to workflows

### How I did it

Added write permissions to all workflows

### How to verify it

look at the workflows files

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
