### PR TITLE
feat: bumping eth-ape version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages, setup  # type: ignore
 
 extras_require = {
     "test": [  # `test` GitHub Action jobs uses this
-        "pytest>=6.0,<8.0",  # Core testing package
+        "pytest>=8.0,<9.0",  # Core testing package
         "pytest-xdist",  # multi-process runner
         "pytest-cov",  # Coverage analyzer plugin
         "hypothesis>=6.2.0,<7.0",  # Strategy-based fuzzer

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
     install_requires=[
         "importlib-metadata ; python_version<'3.8'",
         "boto3>=1.34.79,<2",
-        "eth-ape>=0.7.14,<0.8",
+        "eth-ape>=0.8.2,<0.9",
         "ecdsa>=0.19.0,<1",
     ],  # NOTE: Add 3rd party libraries here
     entry_points={"ape_cli_subcommands": ["ape_aws=ape_aws._cli:cli"]},
@@ -75,8 +75,8 @@ setup(
         "Operating System :: MacOS",
         "Operating System :: POSIX",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
     ],
 )

--- a/tests/test_accounts.py
+++ b/tests/test_accounts.py
@@ -28,7 +28,7 @@ def string_message():
 
 @pytest.fixture(scope="session")
 def aws_account_container():
-    return AwsAccountContainer(data_folder="./", account_type=KmsAccount)
+    return AwsAccountContainer(name="ape-aws", account_type=KmsAccount)
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
### What I did

Bumping the version of eth-ape

### How I did it

change `eth-ape` version in `setup.py`

### How to verify it

ensure a new virtual environment will build properly

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
~~- [ ] New test cases have been added and are passing~~
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
