### PR TITLE
fix: need alias property for accounts

### DIFF
--- a/ape_aws/accounts.py
+++ b/ape_aws/accounts.py
@@ -40,7 +40,7 @@ class KmsAccount(AccountAPI):
 
     @property
     def alias(self) -> str:
-        return self.key_alias.split("/")[-1]
+        return self.key_alias.replace("alias/", "")
 
     @property
     def public_key(self):

--- a/ape_aws/accounts.py
+++ b/ape_aws/accounts.py
@@ -40,7 +40,7 @@ class KmsAccount(AccountAPI):
 
     @property
     def alias(self) -> str:
-        return self.key_alias
+        return self.key_alias.strip("alias/")
 
     @property
     def public_key(self):

--- a/ape_aws/accounts.py
+++ b/ape_aws/accounts.py
@@ -40,7 +40,7 @@ class KmsAccount(AccountAPI):
 
     @property
     def alias(self) -> str:
-        return self.key_alias.strip("alias/")
+        return self.key_alias.split("/")[1]
 
     @property
     def public_key(self):

--- a/ape_aws/accounts.py
+++ b/ape_aws/accounts.py
@@ -40,7 +40,7 @@ class KmsAccount(AccountAPI):
 
     @property
     def alias(self) -> str:
-        return self.key_alias.split("/")[1]
+        return self.key_alias.split("/")[-1]
 
     @property
     def public_key(self):

--- a/ape_aws/accounts.py
+++ b/ape_aws/accounts.py
@@ -39,6 +39,10 @@ class KmsAccount(AccountAPI):
     key_arn: str
 
     @property
+    def alias(self) -> str:
+        return self.key_alias
+
+    @property
     def public_key(self):
         return kms_client.get_public_key(self.key_id)
 

--- a/ape_aws/client.py
+++ b/ape_aws/client.py
@@ -88,7 +88,7 @@ class KmsClient:
             AliasResponse(**page)
             for alias_data in pages
             for page in alias_data["Aliases"]
-            if "alias/aws" not in page["AliasName"]
+            if "alias/aws/" not in page["AliasName"]
         ]
 
     def get_public_key(self, key_id: str):


### PR DESCRIPTION
### What I did

fixes: #10 

### How I did it

Added `alias` property to `KmsAccount

### How to verify it

```bash
$ ape accounts list --all
```
```bash
Found 4 accounts in the 'aws' plugin:
  0xFC28b8BBf5Dc0D85804a21c5C5412fD1BAd39b5C (alias: 'EthKMSKey')
  0xa11F0200c0F4292B44501051Fc1B3B13dda8c010 (alias: 'KeyAlias')
  0x532B0Fd2569494e6c2c7429B50ea949bF2a0B9cA (alias: 'importedTestKey')
  0xE1eFB6289EF575CeBa78115502894E099Ec3FD20 (alias: 'testingKey')

Found 4 accounts in the 'accounts' plugin:
  0x8082513C5794917c91F8dAcc2303Ed65e0B0bD65 (alias: 'ape_test')
  0x47c93237A35510D91b85f01454F82Af7f620bD6c (alias: 'main')
  0x47c93237A35510D91b85f01454F82Af7f620bD6c (alias: 'acc0')
  0x6ed7A062D364771cD4e3BAe42E46E32752f296A8 (alias: 'acc1')
```

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
