### PR TITLE
feat: adding import functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ To import an existing private key into KMS:
 ```bash
 $ ape aws kms import KeyAlias
 Enter your private key:
-SUCCESS (ape-aws): Key imported successfully with ID: <key-id>
+SUCCESS: Key imported successfully with ID: <key-id>
 ```
 
 You can also import a private key from a file (from hex or bytes):
@@ -64,7 +64,7 @@ You can also import a private key from a file (from hex or bytes):
 ```bash
 $ ape aws kms import KeyAlias --private-key <path-to-private-key>
 INFO: Reading private key from <private-key-file>
-SUCCESS (ape-aws): Key imported successfully with ID: <key-id>
+SUCCESS: Key imported successfully with ID: <key-id>
 ```
 
 You can import using a mnemonic phrase as well:

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ ape aws -h
 To create a new key:
 
 ```bash
-ape aws kms create KeyAlias 'Description of new key'
+ape aws kms create KeyAlias -d 'Description of new key'
 ```
 
 To delete this key:

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ You can also import a private key from a file (from hex or bytes):
 
 ```bash
 $ ape aws kms import KeyAlias --private-key <path-to-private-key>
-INFO (ape-aws): Reading private key from <private-key-file>
+INFO: Reading private key from <private-key-file>
 SUCCESS (ape-aws): Key imported successfully with ID: <key-id>
 ```
 

--- a/README.md
+++ b/README.md
@@ -42,13 +42,37 @@ ape aws -h
 To create a new key:
 
 ```bash
-ape aws kms create 'KeyAlias' 'Description of new key'
+ape aws kms create KeyAlias 'Description of new key'
 ```
 
 To delete this key:
 
 ```bash
-ape aws kms delete 'KeyAlias'
+ape aws kms delete KeyAlias
+```
+
+To import an existing private key into KMS:
+
+```bash
+$ ape aws kms import KeyAlias
+Enter your private key:
+SUCCESS (ape-aws): Key imported successfully with ID: <key-id>
+```
+
+You can also import a private key from a file (from hex or bytes):
+
+```bash
+$ ape aws kms import KeyAlias --private-key <path-to-private-key>
+INFO (ape-aws): Reading private key from <private-key-file>
+SUCCESS (ape-aws): Key imported successfully with ID: <key-id>
+```
+
+You can import using a mnemonic phrase as well:
+
+```bash
+$ ape aws kms import KeyAlias --use-mnemonic
+Enter your mnemonic phrase:
+SUCCESS (ape-aws): Key imported successfully with ID: <key-id>
 ```
 
 ### IPython

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ You can import using a mnemonic phrase as well:
 ```bash
 $ ape aws kms import KeyAlias --use-mnemonic
 Enter your mnemonic phrase:
-SUCCESS (ape-aws): Key imported successfully with ID: <key-id>
+SUCCESS: Key imported successfully with ID: <key-id>
 ```
 
 ### IPython

--- a/ape_aws/accounts.py
+++ b/ape_aws/accounts.py
@@ -47,10 +47,9 @@ class AwsAccountContainer(AccountContainerAPI):
                     key_id=key_id,
                     key_arn=key_arn,
                 )
-                keyfile.write_text(
-                    self.loaded_accounts[keyfile.stem].dump_to_json()
-                )
+                keyfile.write_text(self.loaded_accounts[keyfile.stem].dump_to_json())
             return self.loaded_accounts[keyfile.stem]
+
         return map(
             lambda x: _load_account(
                 key_alias=x.alias.replace("alias/", ""),

--- a/ape_aws/accounts.py
+++ b/ape_aws/accounts.py
@@ -1,18 +1,17 @@
-from json import dumps
 from functools import cached_property
+from json import dumps
 from pathlib import Path
 from typing import Any, Iterator, Optional
 
 from ape.api.accounts import AccountAPI, AccountContainerAPI, TransactionAPI
 from ape.types import AddressType, MessageSignature, SignableMessage, TransactionSignature
 from ape.utils.validators import _validate_account_passphrase
-
+from eth_account import Account as EthAccount
 from eth_account._utils.legacy_transactions import serializable_unsigned_transaction_from_dict
 from eth_account.messages import _hash_eip191_message, encode_defunct
-from eth_account import Account as EthAccount
 from eth_pydantic_types import HexBytes
 from eth_typing import Hash32
-from eth_utils import keccak, to_checksum_address, to_bytes
+from eth_utils import keccak, to_bytes, to_checksum_address
 
 from .client import kms_client
 from .utils import _convert_der_to_rsv

--- a/ape_aws/accounts.py
+++ b/ape_aws/accounts.py
@@ -74,6 +74,16 @@ class AwsAccountContainer(AccountContainerAPI):
         print("Key cached successfully")
         return
 
+    def delete_account(self, alias):
+        alias = alias.replace("alias/", "")
+        keyfile = self.data_folder.joinpath(f"{alias}.json")
+        if keyfile.exists():
+            keyfile.unlink()
+            print(f"Key {alias} deleted successfully")
+        else:
+            print(f"Key {alias} not found")
+
+
 class KmsAccount(AccountAPI):
     key_alias: str
     key_id: str

--- a/ape_aws/accounts.py
+++ b/ape_aws/accounts.py
@@ -37,7 +37,7 @@ class AwsAccountContainer(AccountContainerAPI):
 
     @property
     def accounts(self) -> Iterator[AccountAPI]:
-        def _load_account(key_alias, key_id, key_arn) -> Iterator[AccountAPI]:
+        def _load_account(key_alias, key_id, key_arn) -> AccountAPI:
             filename = f"{key_alias}.json"
             keyfile = self.data_folder.joinpath(filename)
             if filename not in self._keyfiles:

--- a/ape_aws/accounts.py
+++ b/ape_aws/accounts.py
@@ -1,5 +1,4 @@
 from functools import cached_property
-from json import dumps
 from typing import Any, Iterator, Optional
 
 from ape.api.accounts import AccountAPI, AccountContainerAPI, TransactionAPI
@@ -107,4 +106,3 @@ class KmsAccount(AccountAPI):
             )
 
         return txn
-

--- a/ape_aws/accounts.py
+++ b/ape_aws/accounts.py
@@ -1,32 +1,20 @@
 from functools import cached_property
 from json import dumps
-from pathlib import Path
 from typing import Any, Iterator, Optional
 
 from ape.api.accounts import AccountAPI, AccountContainerAPI, TransactionAPI
 from ape.types import AddressType, MessageSignature, SignableMessage, TransactionSignature
-from ape.utils.validators import _validate_account_passphrase
-from eth_account import Account as EthAccount
 from eth_account._utils.legacy_transactions import serializable_unsigned_transaction_from_dict
 from eth_account.messages import _hash_eip191_message, encode_defunct
 from eth_pydantic_types import HexBytes
 from eth_typing import Hash32
-from eth_utils import keccak, to_bytes, to_checksum_address
+from eth_utils import keccak, to_checksum_address
 
 from .client import kms_client
 from .utils import _convert_der_to_rsv
 
 
 class AwsAccountContainer(AccountContainerAPI):
-    loaded_accounts: dict[str, "KmsAccount"] = {}
-
-    def model_post_init(self, __context: Any):
-        print("Initializing AWS KMS Account Container")
-        print([acc.alias for acc in self.accounts])
-
-    @property
-    def _keyfiles(self) -> list[Path]:
-        return [file for file in self.data_folder.glob("*.json")]
 
     @property
     def aliases(self) -> Iterator[str]:
@@ -37,49 +25,14 @@ class AwsAccountContainer(AccountContainerAPI):
 
     @property
     def accounts(self) -> Iterator[AccountAPI]:
-        def _load_account(key_alias, key_id, key_arn) -> AccountAPI:
-            filename = f"{key_alias}.json"
-            keyfile = self.data_folder.joinpath(filename)
-            if filename not in self._keyfiles:
-                self.loaded_accounts[keyfile.stem] = KmsAccount(
-                    key_alias=key_alias,
-                    key_id=key_id,
-                    key_arn=key_arn,
-                )
-                keyfile.write_text(self.loaded_accounts[keyfile.stem].dump_to_json())
-            return self.loaded_accounts[keyfile.stem]
-
         return map(
-            lambda x: _load_account(
+            lambda x: KmsAccount(
                 key_alias=x.alias.replace("alias/", ""),
                 key_id=x.key_id,
                 key_arn=x.arn,
             ),
             kms_client.raw_aliases,
         )
-
-    def add_private_key(self, alias, passphrase, private_key):
-        kms_account = self.loaded_accounts[alias]
-        _validate_account_passphrase(passphrase)
-        account = EthAccount.from_key(to_bytes(hexstr=private_key))
-        keyfile = self.data_folder.joinpath(f"{alias}.json")
-        account = EthAccount.encrypt(account.key, passphrase)
-        model = kms_account.model_dump()
-        model["address"] = kms_account.address
-        del account["address"]
-        model.update(account)
-        keyfile.write_text(dumps(model, indent=4))
-        print("Key cached successfully")
-        return
-
-    def delete_account(self, alias):
-        alias = alias.replace("alias/", "")
-        keyfile = self.data_folder.joinpath(f"{alias}.json")
-        if keyfile.exists():
-            keyfile.unlink()
-            print(f"Key {alias} deleted successfully")
-        else:
-            print(f"Key {alias} not found")
 
 
 class KmsAccount(AccountAPI):
@@ -155,7 +108,3 @@ class KmsAccount(AccountAPI):
 
         return txn
 
-    def dump_to_json(self, indent: int = 4):
-        model = self.model_dump()
-        model["address"] = self.address
-        return dumps(model, indent=indent)

--- a/ape_aws/client.py
+++ b/ape_aws/client.py
@@ -1,17 +1,13 @@
-from ape.utils.basemodel import ManagerAccessMixin
-
 from cryptography.hazmat.primitives.asymmetric import ec, padding
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.backends import default_backend
 from eth_account import Account
-from eth_utils import to_bytes
 
 from datetime import datetime
 from typing import ClassVar
 from pydantic import BaseModel, Field, ConfigDict, field_validator
 
 import boto3  # type: ignore[import]
-import json
 
 
 class AliasResponse(BaseModel):

--- a/ape_aws/client.py
+++ b/ape_aws/client.py
@@ -28,7 +28,7 @@ class KeyBaseModel(BaseModel):
 
 
 class CreateKeyModel(KeyBaseModel):
-    description: str = Field(alias="Description")
+    description: str | None = Field(default=None, alias="Description")
     policy: str | None = Field(default=None, alias="Policy")
     key_usage: str = Field(default="SIGN_VERIFY", alias="KeyUsage")
     key_spec: str = Field(default="ECC_SECG_P256K1", alias="KeySpec")

--- a/ape_aws/client.py
+++ b/ape_aws/client.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from pathlib import Path
 from typing import ClassVar
 
 import boto3  # type: ignore[import]
@@ -79,13 +80,11 @@ class ImportKeyRequest(CreateKeyModel):
 class ImportKey(ImportKeyRequest):
     key_id: str = Field(default=None, alias="KeyId")
     public_key: bytes = Field(default=None, alias="PublicKey")
-    private_key: str | bytes | None = Field(default=None, alias="PrivateKey")
+    private_key: str | bytes = Field(default=None, alias="PrivateKey")
     import_token: bytes = Field(default=None, alias="ImportToken")
 
     @field_validator("private_key")
     def validate_private_key(cls, value):
-        if not value:
-            return ec.generate_private_key(ec.SECP256K1(), default_backend())
         if value.startswith("0x"):
             value = value[2:]
         return value

--- a/ape_aws/client.py
+++ b/ape_aws/client.py
@@ -189,7 +189,7 @@ class KmsClient:
         )
         return response.get("Signature")
 
-    def create_key(self, key_spec: CreateKey | ImportKey):
+    def create_key(self, key_spec: CreateKey | ImportKeyRequest):
         response = self.client.create_key(**key_spec.to_aws_dict())
 
         key_id = response["KeyMetadata"]["KeyId"]

--- a/ape_aws/client.py
+++ b/ape_aws/client.py
@@ -1,13 +1,12 @@
-from cryptography.hazmat.primitives.asymmetric import ec, padding
-from cryptography.hazmat.primitives import hashes, serialization
-from cryptography.hazmat.backends import default_backend
-from eth_account import Account
-
 from datetime import datetime
 from typing import ClassVar
-from pydantic import BaseModel, Field, ConfigDict, field_validator
 
 import boto3  # type: ignore[import]
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec, padding
+from eth_account import Account
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 
 class AliasResponse(BaseModel):

--- a/ape_aws/client.py
+++ b/ape_aws/client.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-from pathlib import Path
 from typing import ClassVar
 
 import boto3  # type: ignore[import]

--- a/ape_aws/client.py
+++ b/ape_aws/client.py
@@ -90,11 +90,8 @@ class ImportKey(ImportKeyRequest):
     @field_validator("private_key")
     def validate_private_key(cls, value):
         if not value:
-            return ec.generate_private_key(
-                ec.SECP256K1(),
-                default_backend()
-            )
-        if value.startswith('0x'):
+            return ec.generate_private_key(ec.SECP256K1(), default_backend())
+        if value.startswith("0x"):
             value = value[2:]
         return value
 
@@ -106,14 +103,10 @@ class ImportKey(ImportKeyRequest):
     def ec_private_key(self):
         loaded_key = self.private_key
         if isinstance(loaded_key, bytes):
-            loaded_key = ec.derive_private_key(
-                int(self.private_key, 16), ec.SECP256K1()
-            )
+            loaded_key = ec.derive_private_key(int(self.private_key, 16), ec.SECP256K1())
         elif isinstance(loaded_key, str):
             loaded_key = bytes.fromhex(loaded_key[2:])
-            loaded_key = ec.derive_private_key(
-                int(self.private_key, 16), ec.SECP256K1()
-            )
+            loaded_key = ec.derive_private_key(int(self.private_key, 16), ec.SECP256K1())
         return loaded_key
 
     @property
@@ -165,7 +158,7 @@ class ImportKey(ImportKeyRequest):
                 mgf=padding.MGF1(hashes.SHA256()),
                 algorithm=hashes.SHA256(),
                 label=None,
-            )
+            ),
         )
 
 

--- a/ape_aws/kms/_cli.py
+++ b/ape_aws/kms/_cli.py
@@ -64,6 +64,13 @@ def create_key(
 @kms.command(name="import")
 @ape_cli_context()
 @click.option(
+    "-p",
+    "--private-key",
+    "private_key",
+    multiple=False,
+    help="The private key to import",
+)
+@click.option(
     "-a",
     "--admin",
     "administrators",
@@ -81,7 +88,6 @@ def create_key(
 )
 @click.argument("alias_name")
 @click.argument("description")
-@click.argument("private_key")
 def import_key(
     cli_ctx,
     alias_name: str,
@@ -98,8 +104,8 @@ def import_key(
     )
     key_id = kms_client.create_key(key_spec)
     create_key_response = kms_client.get_parameters(key_id)
-    public_key = base64.b64encode(create_key_response["PublicKey"])
-    import_token = base64.b64encode(create_key_response["ImportToken"])
+    public_key = create_key_response["PublicKey"]
+    import_token = create_key_response["ImportToken"]
     import_key_spec = ImportKey(
         **key_spec.model_dump(),
         key_id=key_id,

--- a/ape_aws/kms/_cli.py
+++ b/ape_aws/kms/_cli.py
@@ -119,7 +119,6 @@ def import_key(
     import_from_mnemonic: bool,
     hd_path: str,
 ):
-    breakpoint()
     if private_key_path:
         if isinstance(private_key_path, str):
             private_key_path = Path(private_key_path)

--- a/ape_aws/kms/_cli.py
+++ b/ape_aws/kms/_cli.py
@@ -127,6 +127,7 @@ def import_key(
         private_key=private_key,
         import_token=import_token,
     )
+    breakpoint()
     response = kms_client.import_key(import_key_spec)
     if response["ResponseMetadata"]["HTTPStatusCode"] != 200:
         cli_ctx.abort("Key failed to import into KMS")

--- a/ape_aws/kms/_cli.py
+++ b/ape_aws/kms/_cli.py
@@ -97,6 +97,18 @@ def create_key(
     metavar="str",
 )
 @click.option(
+    "--from-file",
+    "import_from_file",
+    help="Import a key from a file",
+    is_flag=True,
+)
+@click.option(
+    "--file-path",
+    "file_path",
+    help="The path to the file containing the private key",
+    metavar="str | Path",
+)
+@click.option(
     "--use-mnemonic",
     "import_from_mnemonic",
     help="Import a key from a mnemonic phrase",
@@ -112,15 +124,18 @@ def create_key(
 def import_key(
     cli_ctx,
     alias_name: str,
-    private_key: bytes | str | Path,
+    private_key: bytes | str,
     administrators: list[str],
     users: list[str],
     description: str,
+    import_from_file: bool,
+    file_path: str | Path,
     import_from_mnemonic: bool,
     hd_path: str,
 ):
-    if private_key:
-        path = Path(private_key)
+    if import_from_file:
+        if isinstance(file_path, str):
+            path = Path(private_key)
         if path.exists() and path.is_file():
             cli_ctx.logger.info(f"Reading private key from {path}")
             private_key = path.read_text().strip()

--- a/ape_aws/kms/_cli.py
+++ b/ape_aws/kms/_cli.py
@@ -1,10 +1,9 @@
-import click
 from pathlib import Path
 
+import click
+from ape.cli import ape_cli_context
 from eth_account import Account as EthAccount
 from eth_account.hdaccount import ETHEREUM_DEFAULT_PATH
-
-from ape.cli import ape_cli_context
 
 from ape_aws.client import CreateKey, DeleteKey, ImportKey, ImportKeyRequest, kms_client
 

--- a/ape_aws/kms/_cli.py
+++ b/ape_aws/kms/_cli.py
@@ -1,4 +1,3 @@
-import base64
 import click
 
 from ape.cli import ape_cli_context

--- a/ape_aws/kms/_cli.py
+++ b/ape_aws/kms/_cli.py
@@ -135,7 +135,7 @@ def import_key(
         private_key = account.key.hex()
 
     else:
-        private_key = click.prompt("Enter your private key: ", hide_input=True)
+        private_key = click.prompt("Enter your private key", hide_input=True)
 
     key_spec = ImportKeyRequest(
         alias=alias_name,

--- a/ape_aws/kms/_cli.py
+++ b/ape_aws/kms/_cli.py
@@ -1,14 +1,8 @@
 import click
-
 from ape.cli import ape_cli_context
+
 from ape_aws.accounts import AwsAccountContainer, KmsAccount
-from ape_aws.client import (
-    CreateKey,
-    DeleteKey,
-    ImportKeyRequest,
-    ImportKey,
-    kms_client,
-)
+from ape_aws.client import CreateKey, DeleteKey, ImportKey, ImportKeyRequest, kms_client
 
 
 @click.group("kms")

--- a/ape_aws/kms/_cli.py
+++ b/ape_aws/kms/_cli.py
@@ -28,14 +28,19 @@ def kms():
     help="Apply key policy to a list of users if applicable, ex. -u ARN1, -u ARN2",
     metavar="list[ARN]",
 )
+@click.option(
+    "-d",
+    "--description",
+    "description",
+    help="The description of the key you intend to create.",
+)
 @click.argument("alias_name")
-@click.argument("description")
 def create_key(
     cli_ctx,
     alias_name: str,
-    description: str,
     administrators: list[str],
     users: list[str],
+    description: str,
 ):
     """
     Create an Ethereum Private Key in AWS KmsAccount

--- a/ape_aws/kms/_cli.py
+++ b/ape_aws/kms/_cli.py
@@ -149,9 +149,7 @@ def import_key(
     try:
         response = kms_client.import_key(import_key_spec)
         if response["ResponseMetadata"]["HTTPStatusCode"] != 200:
-            cli_ctx.abort(
-                f"Key failed to import into KMS, {response['Error']}"
-            )
+            cli_ctx.abort(f"Key failed to import into KMS, {response['Error']}")
         cli_ctx.logger.success(f"Key imported successfully with ID: {key_id}")
     except Exception as e:
         cli_ctx.logger.error(f"Key failed to import into KMS: {e}")

--- a/ape_aws/kms/_cli.py
+++ b/ape_aws/kms/_cli.py
@@ -146,10 +146,15 @@ def import_key(
         private_key=private_key,  # type: ignore
         import_token=import_token,  # type: ignore
     )
-    response = kms_client.import_key(import_key_spec)
-    if response["ResponseMetadata"]["HTTPStatusCode"] != 200:
-        cli_ctx.abort("Key failed to import into KMS")
-    cli_ctx.logger.success(f"Key imported successfully with ID: {key_id}")
+    try:
+        response = kms_client.import_key(import_key_spec)
+        if response["ResponseMetadata"]["HTTPStatusCode"] != 200:
+            cli_ctx.abort(
+                f"Key failed to import into KMS, {response['Error']}"
+            )
+        cli_ctx.logger.success(f"Key imported successfully with ID: {key_id}")
+    except Exception as e:
+        cli_ctx.logger.error(f"Key failed to import into KMS: {e}")
 
 
 # TODO: Add `ape aws kms sign-message [message]`

--- a/ape_aws/kms/_cli.py
+++ b/ape_aws/kms/_cli.py
@@ -127,7 +127,6 @@ def import_key(
         private_key=private_key,
         import_token=import_token,
     )
-    breakpoint()
     response = kms_client.import_key(import_key_spec)
     if response["ResponseMetadata"]["HTTPStatusCode"] != 200:
         cli_ctx.abort("Key failed to import into KMS")

--- a/ape_aws/kms/_cli.py
+++ b/ape_aws/kms/_cli.py
@@ -21,7 +21,6 @@ def kms():
     "administrators",
     multiple=True,
     help="Apply key policy to a list of administrators if applicable, ex. -a ARN1, -a ARN2",
-    metavar="list[ARN]",
 )
 @click.option(
     "-u",
@@ -29,7 +28,6 @@ def kms():
     "users",
     multiple=True,
     help="Apply key policy to a list of users if applicable, ex. -u ARN1, -u ARN2",
-    metavar="list[ARN]",
 )
 @click.option(
     "-d",
@@ -71,7 +69,6 @@ def create_key(
     "private_key_path",
     type=click.Path(),
     help="The private key you intend to import",
-    metavar="Path",
 )
 @click.option(
     "-a",
@@ -79,7 +76,6 @@ def create_key(
     "administrators",
     multiple=True,
     help="Apply key policy to a list of administrators if applicable, ex. -a ARN1, -a ARN2",
-    metavar="ARN",
 )
 @click.option(
     "-u",
@@ -87,14 +83,12 @@ def create_key(
     "users",
     multiple=True,
     help="Apply key policy to a list of users if applicable, ex. -u ARN1, -u ARN2",
-    metavar="list[ARN]",
 )
 @click.option(
     "-d",
     "--description",
     "description",
     help="The description of the key you intend to create.",
-    metavar="str",
 )
 @click.option(
     "--use-mnemonic",
@@ -106,7 +100,7 @@ def create_key(
     "--hd-path",
     "hd_path",
     help="The hierarchical deterministic path to derive the key from",
-    metavar="str",
+    default=ETHEREUM_DEFAULT_PATH,
 )
 @click.argument("alias_name")
 def import_key(
@@ -127,8 +121,6 @@ def import_key(
             private_key = private_key_path.read_text().strip()
 
     elif import_from_mnemonic:
-        if not hd_path:
-            hd_path = ETHEREUM_DEFAULT_PATH
         mnemonic = click.prompt("Enter your mnemonic phrase", hide_input=True)
         EthAccount.enable_unaudited_hdwallet_features()
         account = EthAccount.from_mnemonic(mnemonic, account_path=hd_path)

--- a/ape_aws/kms/_cli.py
+++ b/ape_aws/kms/_cli.py
@@ -119,6 +119,7 @@ def import_key(
     import_from_mnemonic: bool,
     hd_path: str,
 ):
+    breakpoint()
     if private_key_path:
         if isinstance(private_key_path, str):
             private_key_path = Path(private_key_path)
@@ -135,7 +136,7 @@ def import_key(
         private_key = account.key.hex()
 
     else:
-        private_key = input("Enter your private key: ")
+        private_key = click.prompt("Enter your private key: ", hide_input=True)
 
     key_spec = ImportKeyRequest(
         alias=alias_name,

--- a/ape_aws/kms/_cli.py
+++ b/ape_aws/kms/_cli.py
@@ -111,7 +111,7 @@ def import_key(
     passphrase = ask_for_passphrase()
     key_spec = ImportKeyRequest(
         alias=alias_name,
-        description=description,
+        description=description,  # type: ignore
         admins=administrators,
         users=users,
     )
@@ -121,10 +121,10 @@ def import_key(
     import_token = create_key_response["ImportToken"]
     import_key_spec = ImportKey(
         **key_spec.model_dump(),
-        key_id=key_id,
-        public_key=public_key,
-        private_key=private_key,
-        import_token=import_token,
+        key_id=key_id,  # type: ignore
+        public_key=public_key,  # type: ignore
+        private_key=private_key,  # type: ignore
+        import_token=import_token,  # type: ignore
     )
     response = kms_client.import_key(import_key_spec)
     if response["ResponseMetadata"]["HTTPStatusCode"] != 200:

--- a/ape_aws/kms/_cli.py
+++ b/ape_aws/kms/_cli.py
@@ -79,7 +79,7 @@ def create_key(
     "administrators",
     multiple=True,
     help="Apply key policy to a list of administrators if applicable, ex. -a ARN1, -a ARN2",
-    metavar="list[ARN]",
+    metavar="ARN",
 )
 @click.option(
     "-u",

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,7 @@ setup(
         "boto3>=1.34.79,<2",
         "eth-ape>=0.8.2,<0.9",
         "ecdsa>=0.19.0,<1",
+        "cryptography>=37.0.4,<38",
     ],  # NOTE: Add 3rd party libraries here
     entry_points={"ape_cli_subcommands": ["ape_aws=ape_aws._cli:cli"]},
     python_requires=">=3.7,<4",


### PR DESCRIPTION
### What I did

Adding import for Eth private keys to AWS KMS

fixes: #12 

### How I did it

Added functionality, trying to emulate [This Article](https://aws.amazon.com/blogs/database/import-ethereum-private-keys-to-aws-kms/) in python

### How to verify it

`ape aws kms import 'testAlias' 'Description' 'private-key'`

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
