### PR TITLE
fix: EIP155 transaction encoding bug

### DIFF
--- a/ape_aws/accounts.py
+++ b/ape_aws/accounts.py
@@ -11,7 +11,7 @@ from eth_typing import Hash32
 from ape_aws.exceptions import ApeAwsException
 
 from .client import AwsClient
-from .kms.client import KmsKey
+from .kms import KmsKey
 from .utils import _convert_der_to_rsv
 
 

--- a/ape_aws/accounts.py
+++ b/ape_aws/accounts.py
@@ -51,8 +51,8 @@ class KmsAccount(AccountAPI):
             return None
 
         msg_sig = MessageSignature(**_convert_der_to_rsv(signature, 27))
-        # TODO: Figure out how to properly compute v in `_convert_der_to_rsv`
         if not self.check_signature(msghash, msg_sig, recover_using_eip191=False):
+            # NOTE: Best way to determine parity is just to try recovery
             msg_sig = MessageSignature(v=msg_sig.v + 1, r=msg_sig.r, s=msg_sig.s)
 
         return msg_sig
@@ -86,19 +86,16 @@ class KmsAccount(AccountAPI):
         txn_dict = txn.model_dump()
         # NOTE: remove this so doesn't raise below
         txn_dict.pop("from", None)
-        unsigned_txn = serializable_unsigned_transaction_from_dict(txn_dict).hash()
+        unsigned_txn_hash = serializable_unsigned_transaction_from_dict(txn_dict).hash()
 
-        if not (msg_sig := self.sign_raw_msghash(HexBytes(unsigned_txn))):
+        if not (signature := self.sign_raw_msghash(HexBytes(unsigned_txn_hash))):
             return None
 
-        txn.signature = TransactionSignature(
-            # Include 155 chain ID protection
-            # NOTE: We already added 27 above
-            # v=((msg_sig.v - 27) + (2 * txn.chain_id) + 35) if txn.chain_id else msg_sig.v,
-            v=msg_sig.v - 27,
-            # TODO: Figure out why EIP 155 protection isn't working right...
-            r=msg_sig.r,
-            s=msg_sig.s,
-        )
+        # NOTE: We already added 27 to v above, so substract it from v to normalize to {0,1}
+        v = signature.v - 27
+        if txn.chain_id and txn.type == 0:
+            # Include 155 chain ID protection offset
+            v += (2 * txn.chain_id) + 35
 
+        txn.signature = TransactionSignature(v=v, r=signature.r, s=signature.s)
         return txn

--- a/ape_aws/kms/__init__.py
+++ b/ape_aws/kms/__init__.py
@@ -1,5 +1,6 @@
-from .client import KmsClient
+from .client import KmsClient, KmsKey
 
 __all__ = [
     "KmsClient",
+    "KmsKey",
 ]

--- a/ape_aws/utils.py
+++ b/ape_aws/utils.py
@@ -1,13 +1,13 @@
 import ecdsa  # type: ignore[import]
 
-SECP256_K1_N = int("fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141", 16)
-
 
 def _convert_der_to_rsv(signature: bytes, v_adjustment_factor: int = 0) -> dict:
     r, s = ecdsa.util.sigdecode_der(signature, ecdsa.SECP256k1.order)
-    v = v_adjustment_factor
-    if s > SECP256_K1_N / 2:
-        s = SECP256_K1_N - s
-    r = r.to_bytes(32, byteorder="big")
-    s = s.to_bytes(32, byteorder="big")
-    return dict(v=v, r=r, s=s)
+    if s > ecdsa.SECP256k1.order / 2:
+        s = ecdsa.SECP256k1.order - s
+
+    return dict(
+        r=r.to_bytes(32, byteorder="big"),
+        s=s.to_bytes(32, byteorder="big"),
+        v=v_adjustment_factor,
+    )


### PR DESCRIPTION
### What I did

Okay, turns out that per EIP2718 I was simply wrong in when EIP155 applies, and it only applies on type 0 transactions IFF chain_id is known

fixes: #19 

### How I did it

### How to verify it

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
~~- [ ] New test cases have been added and are passing~~
~~- [ ] Documentation has been updated~~
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
