### PR TITLE
fix: avoid exceptions when accessing AWS account container

### DIFF
--- a/ape_aws/exceptions.py
+++ b/ape_aws/exceptions.py
@@ -1,5 +1,16 @@
+from typing import TYPE_CHECKING
+
 from ape.exceptions import ApeException
+from click.exceptions import UsageError
+
+if TYPE_CHECKING:
+    from botocore.exceptions import BotoCoreError  # type: ignore[import-untyped]
 
 
 class ApeAwsException(ApeException):
     pass  # NOTE: For subclassing
+
+
+class AwsAccessError(ApeAwsException, UsageError):
+    def __init__(self, exc: "BotoCoreError"):
+        super().__init__(f"[ape-aws] {exc}")

--- a/ape_aws/iam/client.py
+++ b/ape_aws/iam/client.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from functools import cached_property
 from typing import TYPE_CHECKING, ClassVar
 
-from botocore.exceptions import BotoCoreError
+from botocore.exceptions import BotoCoreError  # type: ignore[import-untyped]
 from pydantic import BaseModel, Field, model_validator
 
 from ape_aws.exceptions import AwsAccessError

--- a/ape_aws/kms/client.py
+++ b/ape_aws/kms/client.py
@@ -4,7 +4,7 @@ from itertools import chain
 from typing import TYPE_CHECKING, ClassVar
 
 from ape.types import AddressType
-from botocore.exceptions import BotoCoreError
+from botocore.exceptions import BotoCoreError  # type: ignore[import-untyped]
 from pydantic import BaseModel, Field, SecretStr, field_validator
 
 from ape_aws.exceptions import AwsAccessError

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,3 +31,4 @@ force_grid_wrap = 0
 include_trailing_comma = true
 multi_line_output = 3
 use_parentheses = true
+skip = ["version.py"]


### PR DESCRIPTION
### What I did

This PR addresses issues where having the AWS plugin installed makes various parts of Ape's internal API not function correctly

fixes: #25

### How I did it

### How to verify it

Do the following while not logged in

```sh
$ ape aws keys list
$ ape aws users list
$ ape accounts list --all
```

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
~~- [ ] Documentation has been updated~~
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
